### PR TITLE
Update HealComm-1.0.lua

### DIFF
--- a/libs/HealComm-1.0/HealComm-1.0.lua
+++ b/libs/HealComm-1.0/HealComm-1.0.lua
@@ -1341,7 +1341,6 @@ function HealComm:SPELLCAST_START()
 		local targetpower, targetmod = self.SpellCastInfo[4], self.SpellCastInfo[5]
 		local Bonus = Bonus + buffpower
 		local amount = ((math.floor(self.Spells[self.SpellCastInfo[1]][tonumber(self.SpellCastInfo[2])](Bonus))+targetpower)*buffmod*targetmod)
-		print("HealComm predicts: "..amount.." Crit: "..1.5*amount)
 		if arg1 == L["Prayer of Healing"] then
 			local targets = {UnitName("player")}
 			local targetsstring = UnitName("player").."/"


### PR DESCRIPTION
Remove print statement. Probably debug print that stayed in.

Printed "HealComm predicts ..." in chat every time a heal is cast. I think this probably came in as a debug print and got forgotten. I didn't find a way to turn it off ingame, so I went to the code. As far as I can tell there is no way to turn it off other than deleting this line and as far as I know the print does not have any other effects.